### PR TITLE
updating deployment to use jfrog for artifact deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,31 @@
 # swagger-grails
+
 Generate Swagger documentation for your Grails 4 app.
 
 ## Built With
+
 * Java 11
 * Grails 4.0.3
 * Swagger Core 1.5.16
 
 ## Installation
+
 Add this line to the `repositories` block in your `build.gradle` file:
-    
-    maven { url "https://dl.bintray.com/steamcleaner/plugins/" }
+
+    maven { url "https://steamcleaner.jfrog.io/artifactory/grails-plugins" }
 
 Add this line to the `dependencies` block in your `build.gradle` file:
-    
+
     compile "org.grails.plugins:swagger-grails:0.4.0"
-    
->>> 
-The <code>swagger-servlet</code> dependency includes a logback-test.xml file, which will override
-any logback file that you have declared in your app.  To circumvent this in the mean time, just include a logback-test.groovy file in your application that is a copy of the logback.groovy file.
->>>
+
+> The <code>swagger-servlet</code> dependency includes a logback-test.xml file, which will override
+> any logback file that you have declared in your app. To circumvent this in the mean time, just include a logback-test.groovy
+> file in your application that is a copy of the logback.groovy file.
 
 ## Usage
+
 Given the following UrlMappings.groovy
+
 ```groovy
 class UrlMappings {
     static mappings = {
@@ -37,6 +41,7 @@ class UrlMappings {
 ```
 
 ... and the following AuthorController.groovy ...
+
 ```groovy
 class AuthorController {
     def index() {/*...*/ }
@@ -65,46 +70,49 @@ class AuthorCommand implements Validateable {
     <img src="src/test/resources/author-controller.png?raw=true" />
 </p>
 
-This plugin will only generate the JSON representation of your endpoints. You'll
-need to implement your own [swagger-ui](https://github.com/swagger-api/swagger-ui) to consume the JSON.
+This plugin will only generate the JSON representation of your endpoints. You'll need to implement your
+own [swagger-ui](https://github.com/swagger-api/swagger-ui) to consume the JSON.
 
-If your `UrlMappings` file includes the default `"/$controller/$action?/$id?(.$format)?"` mapping then
-the JSON will be acessible by hitting http://localhost:8080/swagger/api.  This endpoint
-can be customized by adding `"/custom/swagger/endpoint"(controller: "swagger", action: "api")` to your
-UrlMappings file.
+If your `UrlMappings` file includes the default `"/$controller/$action?/$id?(.$format)?"` mapping then the JSON will be
+acessible by hitting http://localhost:8080/swagger/api. This endpoint can be customized by
+adding `"/custom/swagger/endpoint"(controller: "swagger", action: "api")` to your UrlMappings file.
 
-Also any Swagger annotations that are manually added to actions in  controllers
-will be used when generating the Swagger documentation. So you could let the
-plugin do what it does by default and then enhance the actions with responses,
+Also any Swagger annotations that are manually added to actions in controllers will be used when generating the Swagger
+documentation. So you could let the plugin do what it does by default and then enhance the actions with responses,
 authorizations, etc...
 
 ## Configuration
+
 The plugin also exposes the ability to customize the Swagger instance that is used.
 
 The following resources.groovy ...
+
 ```groovy
     swagger(Swagger) {
         securityDefinitions = ["apiKey": new ApiKeyAuthDefinition("apiKey", In.HEADER)]
         security = [new SecurityRequirement().requirement("apiKey")]
     }
 ```
-... will create the default swagger instance that the plugin will use.  It also sets the
- security definition and security block.  Together these two allow a header "apiKey"
- to be attached to all calls from the front end.
- 
- Any of the fields on the Swagger object can be configured this way as well.  For some more
- info on what can be configured the [OpenAPI-Specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#schema) describes what the Swagger
- object can contain.
+
+... will create the default swagger instance that the plugin will use. It also sets the security definition and security
+block. Together these two allow a header "apiKey"
+to be attached to all calls from the front end.
+
+Any of the fields on the Swagger object can be configured this way as well. For some more info on what can be configured
+the [OpenAPI-Specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#schema) describes
+what the Swagger object can contain.
 
 ## Running the plugin locally
-The plugin source contains more examples of what types of configuration you
-can apply to controllers and actions :
+
+The plugin source contains more examples of what types of configuration you can apply to controllers and actions :
 
 ##### Prerequisites
+
 * Java 11
 * Grails 4.0.3
 
 ##### Running
+
 * Clone or download the repo
 * Run `grails run-app`
 * Navigate to `http://localhost:8080/`

--- a/build.gradle
+++ b/build.gradle
@@ -12,8 +12,8 @@ group "org.grails.plugins"
 
 apply plugin: "eclipse"
 apply plugin: "idea"
+apply plugin: "maven-publish"
 apply plugin: "org.grails.grails-plugin"
-apply plugin: "org.grails.grails-plugin-publish"
 
 repositories {
     maven { url "https://repo.grails.org/grails/core" }
@@ -73,11 +73,21 @@ tasks.withType(GroovyCompile) {
 }
 
 bootJar.enabled = false
-grailsPublish {
-    githubSlug = 'steamcleaner/swagger-grails'
-    license {
-        name = 'Apache-2.0'
+
+publishing {
+    repositories {
+        maven {
+            url 'https://steamcleaner.jfrog.io/artifactory/grails-plugins/'
+            credentials {
+                username System.getenv('JFR_USERNAME')
+                password System.getenv('JFR_TOKEN')
+            }
+        }
     }
-    title = "swagger-grails"
-    developers = [steamcleaner: "steamcleaner"]
+
+    publications {
+        maven(MavenPublication) {
+            from components.java
+        }
+    }
 }


### PR DESCRIPTION
Bintray being sunsetted necessitated the need to migrate to jfrog for hosting the built artifacts.

Fixes #5 